### PR TITLE
Reserved words aren't identifiers

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,7 +61,6 @@ function weirdify({ types: t }) {
 
         if (
           path.scope.globals[name] ||
-          reservedWords.includes(name) ||
           isObjectProperty(path) ||
           dictionary[name]
         ) {


### PR DESCRIPTION
If all else fails you can use `t.isValidIdentifier`